### PR TITLE
Fuzz fixes

### DIFF
--- a/fuzz/install
+++ b/fuzz/install
@@ -46,4 +46,4 @@ git clone https://github.com/stellar/stellar-core stellar-core
 cd stellar-core
 ./autogen.sh
 ./configure --enable-afl
-make
+make -j $(nproc)

--- a/fuzz/install
+++ b/fuzz/install
@@ -24,6 +24,7 @@ apt-get install -y \
 update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 90 --slave /usr/bin/g++ g++ /usr/bin/g++-4.9
 update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.5 90 --slave /usr/bin/clang++ clang++ /usr/bin/clang++-3.5
 update-alternatives --install /usr/bin/llvm-symbolizer llvm-symbolizer /usr/bin/llvm-symbolizer-3.5 90
+update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-3.5 90
 
 # for the core_file_processor
 apt-get install -y python-pip
@@ -34,6 +35,7 @@ wget -nv -O afl-${AFL_VERSION}.tgz http://lcamtuf.coredump.cx/afl/releases/afl-$
 tar -zxf afl-${AFL_VERSION}.tgz
 cd afl-${AFL_VERSION}
 make
+make -C llvm_mode
 make install
 cd ..
 rm -rf afl-${AFL_VERSION}

--- a/fuzz/start
+++ b/fuzz/start
@@ -3,4 +3,5 @@
 set -e
 
 cd stellar-core
+export AFL_PERSISTENT=1
 make fuzz


### PR DESCRIPTION
This updates the Dockerfile.fuzz machinery to match the changes in stellar/stellar-core#586 that switch the fuzzer over to LLVM-based "fast" AFL mode as well as its PERSISTENT sub-mode. Results in 4-5x speedup. This change is necessary for compatibility with those changes, not optional.
