### PR TITLE
Get metrics publishing again

### DIFF
--- a/confd/templates/hekad.toml.tmpl
+++ b/confd/templates/hekad.toml.tmpl
@@ -69,3 +69,10 @@ stderr = true
 
 [DashboardOutput]
 ticker_interval = 1
+
+[DebugOutput]
+message_matcher = "Type == 'heka.sandbox-terminated'"
+type = "LogOutput"
+encoder = "RstEncoder"
+
+[RstEncoder]


### PR DESCRIPTION
We ran into an issue on stellar-core where the final atlas metrics payload was > 64kB so heka wouldn't route it (internal hard limit on message size).

This splits it up to 80 top level metrics at a time to get safely below that limit.

It should probably get generalized so we don't run into the same problem with horizon, I have code that might work, but since it's from horizon's heka it doesn't have built in white-listing.

Without whitelisting out a handful of stats I ended up needing to crank the limit down to like 20 metrics per payload.

For this time being this will at least get metrics flowing for stellar-core again so we can build alerts on them.