### PR TITLE
use Google's AFL repo and bump to 2.53b

### DIFF
--- a/Dockerfile.fuzz
+++ b/Dockerfile.fuzz
@@ -2,7 +2,7 @@ FROM stellar/base:latest
 
 MAINTAINER Mat Schaffer <mat@stellar.org>
 
-ENV AFL_VERSION 2.52b
+ENV AFL_VERSION 2.53b
 
 ADD fuzz/install /
 RUN /install

--- a/fuzz/install
+++ b/fuzz/install
@@ -38,14 +38,14 @@ apt-get install -y python-pip
 pip install boto
 
 # for the fuzzer
-wget -nv -O afl-${AFL_VERSION}.tgz http://lcamtuf.coredump.cx/afl/releases/afl-${AFL_VERSION}.tgz
+wget -nv -O afl-${AFL_VERSION}.tgz https://github.com/google/AFL/archive/v${AFL_VERSION}.tar.gz
 tar -zxf afl-${AFL_VERSION}.tgz
-cd afl-${AFL_VERSION}
+cd AFL-${AFL_VERSION}
 make
 make -C llvm_mode CXX=g++
 make install
 cd ..
-rm -rf afl-${AFL_VERSION}
+rm -rf AFL-${AFL_VERSION}
 rm afl-${AFL_VERSION}.tgz
 
 # build stellar-core under fuzzer


### PR DESCRIPTION
AFL was recently revived by Google and as a part of this revival, the version was bumped and the repo was moved: https://github.com/google/AFL

Announcement: https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/afl-users/WX8NdcB9GmM