### PR TITLE
Fix fuzz build

### DIFF
--- a/fuzz/install
+++ b/fuzz/install
@@ -53,7 +53,7 @@ git clone https://github.com/stellar/stellar-core stellar-core
 cd stellar-core
 ./autogen.sh
 ./configure --enable-afl
-make -j $(nproc)
+make -j $(nproc) CXXFLAGS="-std=c++14"
 
 # clean out objects post-build, rebuild with make -t (touch)
 find / -name \*.o | xargs rm


### PR DESCRIPTION
I am by no means a docker or makefile expert, however I believe, after running the following locally and after reproducing the errors from Jenkins, these should fix the errors observed:
* *pandoc missing*
* `requires compiler and library support for the ISO C++ 2011 standard.`