### PR TITLE
add sqlite3 to image

### DIFF
--- a/install
+++ b/install
@@ -17,7 +17,7 @@ apt-get install -y python-pip
 pip install awscli --upgrade  # for uploading history to s3
 pip install boto              # for sending crash emails
 
-apt-get install -y postgresql-client
+apt-get install -y postgresql-client sqlite3
 
 [[ -f stellar-core.deb ]] || wget -nv -O stellar-core.deb https://s3.amazonaws.com/stellar.org/releases/stellar-core/stellar-core-${STELLAR_CORE_VERSION}_amd64.deb
 


### PR DESCRIPTION
Currently some test automation is pulling in a 3rd party unofficial sqlite container in order to have the sqlite3 command-line client on hand to perform a database dump with. This just folds it into the main stellar-core container. It's reasonably small (~2mb) and frequently useful for field diagnostics anyway.